### PR TITLE
FIX: modify Fargate bastion Dockerfile; install MySQL GPG key #6 

### DIFF
--- a/fargate-bastion/Dockerfile
+++ b/fargate-bastion/Dockerfile
@@ -1,5 +1,6 @@
 FROM amazonlinux:2
 RUN yum install -y sudo jq awscli shadow-utils htop lsof telnet bind-utils yum-utils && \
+    rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022 && \
     yum install -y https://s3.ap-northeast-1.amazonaws.com/amazon-ssm-ap-northeast-1/latest/linux_amd64/amazon-ssm-agent.rpm && \
     yum install -y yum localinstall https://dev.mysql.com/get/mysql80-community-release-el7-3.noarch.rpm && \
     yum-config-manager --disable mysql80-community && \


### PR DESCRIPTION
#6 に詳細書かれておりますが、どうも2022年1月18日に[MySQL8.0.28](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-28.html)がリリースされたタイミングでGPGキーが変更になったようです。

rpmでインストールする処理を追加しました。
`rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022`

参考: [MySQLの公式ドキュメント](https://dev.mysql.com/doc/mysql-yum-repo-quick-guide/en/)
